### PR TITLE
Oemc 24 users can sort items in the landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Unreleased
 - Display of monitors and geostories in landing page [OEMC-25](https://vizzuality.atlassian.net/browse/OEMC-25?atlOrigin=eyJpIjoiNDZiOTM0YjkzN2NlNDJhNmE2OWJiODYxZTlmYzcwNjkiLCJwIjoiaiJ9)
 - Search monitors and geostories by title [OEMC-94](https://vizzuality.atlassian.net/browse/OEMC-94?atlOrigin=eyJpIjoiMGVlYmJhNmM5ODU4NDRiNWEzNTIyNWRjODdjNDg4MWUiLCJwIjoiaiJ9)
 - 404 - error management [OEMC-81](https://vizzuality.atlassian.net/browse/OEMC-81?atlOrigin=eyJpIjoiNWZkNTYwMjVkZGVjNDAwZGE2YWI3ZDgwMzgzOTRjMjEiLCJwIjoiaiJ9)
+- Sorting items in landing page [OEMC-24](https://vizzuality.atlassian.net/browse/OEMC-24?atlOrigin=eyJpIjoiZTlmNGE1Njk3MTRlNDNjMmExY2I3YmE1ZjUzMTBkYjIiLCJwIjoiaiJ9)
 
 ### Changed
 

--- a/e2e/datasets-hub.spec.ts
+++ b/e2e/datasets-hub.spec.ts
@@ -9,11 +9,11 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('monitors and geostories display', () => {
   test('monitors display', async ({ page }) => {
-    const monitorsCheckbox = page.getByTestId('monitors-button');
+    const monitorsCheckbox = page.getByTestId('monitors-button-checkbox');
     await monitorsCheckbox.click();
 
     const monitorsResponse = await page.waitForResponse(
-      'https://api.earthmonitor.org/monitors-and-geostories?type=monitors'
+      'https://api.earthmonitor.org/monitors-and-geostories?type=monitors&sort_by=title'
     );
 
     const monitorsData = (await monitorsResponse.json()) as Monitor[];
@@ -56,11 +56,11 @@ test.describe('monitors and geostories display', () => {
   });
 
   test('geostories display', async ({ page }) => {
-    const geostoriesCheckbox = page.getByTestId('geostories-button');
+    const geostoriesCheckbox = page.getByTestId('geostories-button-checkbox');
     await geostoriesCheckbox.click();
 
     const geostoriesResponse = await page.waitForResponse(
-      'https://api.earthmonitor.org/monitors-and-geostories?type=geostories'
+      'https://api.earthmonitor.org/monitors-and-geostories?type=geostories&sort_by=title'
     );
 
     const geostoriesData = (await geostoriesResponse.json()) as Geostory[];
@@ -88,11 +88,8 @@ test.describe('monitors and geostories display', () => {
   });
 
   test('geostories and monitors display', async ({ page }) => {
-    const geostoriesCheckbox = page.getByTestId('all-button');
-    await geostoriesCheckbox.click();
-
     const datasetsResponse = await page.waitForResponse(
-      'https://api.earthmonitor.org/monitors-and-geostories'
+      'https://api.earthmonitor.org/monitors-and-geostories?sort_by=title'
     );
 
     const datasetsData = (await datasetsResponse.json()) as (Monitor | Geostory)[];
@@ -104,14 +101,14 @@ test.describe('monitors and geostories display', () => {
   });
 
   test('geostories and monitors number of results display', async ({ page }) => {
-    const geostoriesCheckbox = page.getByTestId('geostories-button');
+    const geostoriesCheckbox = page.getByTestId('geostories-button-checkbox');
     await geostoriesCheckbox.click();
 
     const datasetsResponse = await page.waitForResponse(
-      'https://api.earthmonitor.org/monitors-and-geostories?type=geostories'
+      'https://api.earthmonitor.org/monitors-and-geostories?type=geostories&sort_by=title'
     );
 
-    const datasetsData = (await datasetsResponse.json()) as (Monitor | Geostory)[];
+    const datasetsData = (await datasetsResponse.json()) as Geostory[];
 
     const resultNumber = page.getByTestId('result-number');
     const result = datasetsData.length.toString();

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -10,13 +10,13 @@ test.beforeEach(async ({ page }) => {
 test.describe('search of monitors and geostories', () => {
   test('search by title', async ({ page }) => {
     const response = await page.waitForResponse(
-      'https://api.earthmonitor.org/monitors-and-geostories'
+      'https://api.earthmonitor.org/monitors-and-geostories?sort_by=title'
     );
     const datasetsData = (await response.json()) as (Monitor | Geostory)[];
     const searchInput = page.getByTestId('search-input');
 
     const searchPromise = page.waitForResponse(
-      'https://api.earthmonitor.org/monitors-and-geostories?title=*'
+      'https://api.earthmonitor.org/monitors-and-geostories?title=*&sort_by=title'
     );
     await searchInput.fill(datasetsData[0].title);
     const filteredResponse = await searchPromise;

--- a/e2e/sort.spec.ts
+++ b/e2e/sort.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+// import { orderBy } from 'lodash-es';
+
+import type { Geostory } from '@/types/geostories';
+import type { Monitor } from '@/types/monitors';
+
+type MonitorsAndGeostoriesResponse = Geostory & Monitor;
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/', { waitUntil: 'load' });
+});
+
+test.describe('sort monitors and geostories', () => {
+  // test('sort by id', async ({ page }) => {
+  //   const response = await page.waitForResponse(
+  //     'https://api.earthmonitor.org/monitors-and-geostories?sort_by=title'
+  //   );
+
+  //   const defaultOrderedDataByTitle = (await response.json()) as MonitorsAndGeostoriesResponse[];
+  //   const sortByIdCheckbox = page.getByTestId('id-button');
+
+  //   await sortByIdCheckbox.click();
+  //   const sortPromise = page.waitForResponse(
+  //     'https://api.earthmonitor.org/monitors-and-geostories?sort_by=id'
+  //   );
+  //   const sortedResponse = await sortPromise;
+  //   const sortedByIdResponse = (await sortedResponse.json()) as MonitorsAndGeostoriesResponse[];
+
+  //   const monitors = defaultOrderedDataByTitle.filter((item) => item.geostories);
+  //   const geostories = defaultOrderedDataByTitle.filter((item) => item.layers);
+  //   const orderedMonitorsById = orderBy(monitors, ['id']) satisfies Monitor[];
+  //   const orderedGeostoriesById = orderBy(geostories, ['id']) satisfies Geostory[];
+  //   expect(sortedByIdResponse).toEqual([...orderedMonitorsById, ...orderedGeostoriesById]);
+  // }); TO - DO - fix when API gets ready
+
+  // test('sort by date', async ({ page }) => {
+  //   const response = await page.waitForResponse(
+  //     'https://api.earthmonitor.org/monitors-and-geostories?sort_by=title'
+  //   );
+
+  //   const defaultOrderedDataByTitle = (await response.json()) as MonitorsAndGeostoriesResponse[];
+  //   const sortByDateCheckbox = page.getByTestId('date-button');
+
+  //   await sortByDateCheckbox.click();
+  //   const sortPromise = page.waitForResponse(
+  //     'https://api.earthmonitor.org/monitors-and-geostories?sort_by=date'
+  //   );
+  //   const sortedResponse = await sortPromise;
+  //   const sortedByDateResponse = (await sortedResponse.json()) as MonitorsAndGeostoriesResponse[];
+
+  //   const monitors = defaultOrderedDataByTitle.filter((item) => item.geostories);
+  //   const geostories = defaultOrderedDataByTitle.filter((item) => item.layers);
+  //   const orderedMonitorsByDate = orderBy(monitors, ['date']) satisfies Monitor[];
+  //   const orderedGeostoriesByDate = orderBy(geostories, ['date']) satisfies Geostory[];
+  //   expect(sortedByDateResponse).toEqual([...orderedMonitorsByDate, ...orderedGeostoriesByDate]);
+  // }); TO - DO - fix when API gets ready
+
+  test('sort by title (default option)', async ({ page }) => {
+    const response = await page.waitForResponse(
+      'https://api.earthmonitor.org/monitors-and-geostories?sort_by=title'
+    );
+
+    const defaultOrderedDataByTitle = (await response.json()) as MonitorsAndGeostoriesResponse[];
+
+    const monitors = defaultOrderedDataByTitle?.filter((item) => item.geostories);
+    const geostories = defaultOrderedDataByTitle?.filter((item) => item.layers);
+
+    const orderedMonitorsByTitle = monitors?.sort((a, b) =>
+      a.title > b.title ? 1 : a.title < b.title ? -1 : 0
+    ) satisfies Monitor[];
+    const orderedGeostoriesByTitle = geostories?.sort((a, b) =>
+      a.title > b.title ? 1 : a.title < b.title ? -1 : 0
+    ) satisfies Geostory[];
+    expect(defaultOrderedDataByTitle).toEqual([
+      ...orderedMonitorsByTitle,
+      ...orderedGeostoriesByTitle,
+    ]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@playwright/test": "1.37.1",
     "@types/google.analytics": "0.0.42",
-    "@types/lodash-es": "4.17.9",
+    "@types/lodash-es": "4.17.10",
     "@types/node": "20.5.7",
     "@types/ol-ext": "npm:@siedlerchr/types-ol-ext@3.2.4",
     "@types/react": "18.2.31",
@@ -89,6 +89,7 @@
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "8.0.3",
+    "next-usequerystate": "1.9.2",
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.3.0",
     "typescript": "5.0.4"

--- a/src/components/datasets-grid/constants/index.ts
+++ b/src/components/datasets-grid/constants/index.ts
@@ -1,11 +1,9 @@
-export type Theme =
-  | 'Water'
-  | 'Agriculture'
-  | 'Biodiversity'
-  | 'Soil'
-  | 'Climate & Health'
-  | 'Forest';
+import type { SortingCriteria, Theme } from '../types';
 
+export const SORTING = [
+  'title',
+  //  'date' TO - Do add sorting by date when API gets ready
+] satisfies SortingCriteria[];
 export const THEMES = [
   'Water',
   'Agriculture',

--- a/src/components/datasets-grid/types.d.ts
+++ b/src/components/datasets-grid/types.d.ts
@@ -1,0 +1,10 @@
+export type SortingCriteria = 'title';
+// | 'date' TO - DO: add date sorting when API gets readdy
+export type Theme =
+  | 'Water'
+  | 'Agriculture'
+  | 'Biodiversity'
+  | 'Soil'
+  | 'Climate & Health'
+  | 'Forest';
+export type Dataset = 'monitors' | 'geostories' | 'all';

--- a/src/components/landing-card/index.tsx
+++ b/src/components/landing-card/index.tsx
@@ -11,7 +11,6 @@ const Card: FC<{
 }> = ({ title, id, ...data }) => {
   const isMonitor = id.startsWith('m');
   const isGeostory = id.startsWith('g');
-
   return (
     <motion.div
       className="overflow-hidden font-inter"

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -25,7 +25,10 @@ const Checkbox = forwardRef<
 
 const CheckboxIndicator = forwardRef<
   ElementRef<typeof CheckboxPrimitive.Indicator>,
-  ComponentPropsWithoutRef<typeof CheckboxPrimitive.Indicator>
+  ComponentPropsWithoutRef<typeof CheckboxPrimitive.Indicator> & {
+    children: React.ReactNode;
+    className?: string;
+  }
 >(({ className, children, ...props }, ref) => (
   <CheckboxPrimitive.Indicator
     ref={ref}

--- a/src/components/ui/dropdown.tsx
+++ b/src/components/ui/dropdown.tsx
@@ -3,7 +3,7 @@
 import { forwardRef, ElementRef, ComponentPropsWithoutRef, HTMLAttributes } from 'react';
 
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
-import { CheckIcon, ChevronRightIcon, DotFilledIcon } from '@radix-ui/react-icons';
+import { CheckIcon, DotFilledIcon } from '@radix-ui/react-icons';
 import { HiChevronDown } from 'react-icons/hi2';
 
 import { cn } from 'lib/classnames';
@@ -11,8 +11,6 @@ import { cn } from 'lib/classnames';
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 
 const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
-
-const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
@@ -31,15 +29,18 @@ const DropdownMenuTrigger = forwardRef<
   ElementRef<typeof DropdownMenuPrimitive.Trigger>,
   ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger> & {
     inset?: boolean;
+    children: React.ReactNode;
+    className?: string;
   }
 >(({ className, inset, children, ...props }, ref) => (
   <DropdownMenuPrimitive.Trigger
     ref={ref}
-    className={cn(
-      'group h-full rounded-none border border-secondary-700 px-8 text-secondary-500 hover:bg-secondary-700',
-      inset && 'pl-8',
-      className
-    )}
+    className={cn({
+      'group h-full rounded-none border border-secondary-900 px-8 text-secondary-500 hover:bg-secondary-900':
+        true,
+      'pl-8': inset,
+      [className]: !!className,
+    })}
     {...props}
   >
     <div className="flex w-full items-center space-x-4">
@@ -51,42 +52,6 @@ const DropdownMenuTrigger = forwardRef<
 
 DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName;
 
-const DropdownMenuSubTrigger = forwardRef<
-  ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
-  }
->(({ className, inset, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      'flex cursor-default select-none items-center rounded-sm border-secondary-700 px-2 py-1.5 text-sm outline-none',
-      inset && 'pl-8',
-      className
-    )}
-    {...props}
-  >
-    {children}
-    <ChevronRightIcon className="ml-auto h-4 w-4" />
-  </DropdownMenuPrimitive.SubTrigger>
-));
-DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
-
-const DropdownMenuSubContent = forwardRef<
-  ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'z-50 w-full min-w-[8rem] overflow-hidden border border-secondary-700 p-1 text-popover-foreground text-secondary-500 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-      className
-    )}
-    {...props}
-  />
-));
-DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
-
 const DropdownMenuContent = forwardRef<
   ElementRef<typeof DropdownMenuPrimitive.Content>,
   ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
@@ -96,7 +61,7 @@ const DropdownMenuContent = forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-full min-w-[258px] overflow-hidden border p-1 text-popover-foreground text-secondary-700 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'dropdown-menu-content z-50 w-full overflow-hidden border border-secondary-900 p-1 text-popover-foreground text-secondary-700 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}
@@ -109,23 +74,32 @@ const DropdownMenuItem = forwardRef<
   ElementRef<typeof DropdownMenuPrimitive.Item>,
   ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean;
+    className?: string;
+    children: React.ReactNode;
   }
->(({ className, inset, ...props }, ref) => (
+>(({ className, children, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
-    className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-secondary-700 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      inset && 'pl-8',
-      className
-    )}
+    className={cn({
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-secondary-700 data-[disabled]:pointer-events-none data-[disabled]:opacity-50':
+        true,
+      'pl-8': inset,
+      [className]: !!className,
+    })}
     {...props}
-  />
+  >
+    {children}
+  </DropdownMenuPrimitive.Item>
 ));
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
 const DropdownMenuCheckboxItem = forwardRef<
   ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> & {
+    checked?: boolean;
+    children: React.ReactNode;
+    className?: string;
+  }
 >(({ className, children, checked, ...props }, ref) => (
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
@@ -148,7 +122,10 @@ DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displa
 
 const DropdownMenuRadioItem = forwardRef<
   ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
-  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem> & {
+    children: React.ReactNode;
+    className?: string;
+  }
 >(({ className, children, ...props }, ref) => (
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
@@ -172,11 +149,16 @@ const DropdownMenuLabel = forwardRef<
   ElementRef<typeof DropdownMenuPrimitive.Label>,
   ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
     inset?: boolean;
+    className?: string;
   }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
-    className={cn('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
+    className={cn({
+      'px-2 py-1.5 text-sm font-semibold': true,
+      'pl-8': inset,
+      [className]: !!className,
+    })}
     {...props}
   />
 ));
@@ -184,11 +166,11 @@ DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
 const DropdownMenuSeparator = forwardRef<
   ElementRef<typeof DropdownMenuPrimitive.Separator>,
-  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> & { className?: string }
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-secondary-700', className)}
+    className={cn({ '-mx-1 my-1 h-px bg-secondary-700': true, [className]: !!className })}
     {...props}
   />
 ));
@@ -213,8 +195,5 @@ export {
   DropdownMenuShortcut,
   DropdownMenuGroup,
   DropdownMenuPortal,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuRadioGroup,
 };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -11,9 +11,12 @@ const labelVariants = cva(
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants> & { children: React.ReactNode; className?: string }
+>(({ className, children, ...props }, ref) => (
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), [className])} {...props}>
+    {children}
+  </LabelPrimitive.Root>
 ));
 Label.displayName = LabelPrimitive.Root.displayName;
 

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -9,14 +9,19 @@ import { cn } from '@/lib/classnames';
 
 const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
->(({ className, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root> & {
+    children: React.ReactNode;
+    className?: string;
+  }
+>(({ className, children, ...props }, ref) => {
   return (
     <RadioGroupPrimitive.Root
-      className={cn({ 'grid gap-2': true, [className]: !!className })}
+      className={cn({ 'grid gap-2 text-secondary-500': true, [className]: !!className })}
       {...props}
       ref={ref}
-    />
+    >
+      {children}
+    </RadioGroupPrimitive.Root>
   );
 });
 RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
@@ -28,13 +33,14 @@ const RadioGroupItem = React.forwardRef<
   return (
     <RadioGroupPrimitive.Item
       ref={ref}
-      className={cn(
-        'h-5 w-5 rounded-full border-2 border-primary border-secondary-500 text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-        className
-      )}
+      className={cn({
+        'h-5 w-5 rounded-full border-2 border-primary border-secondary-500 ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50':
+          true,
+        [className]: !!className,
+      })}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center rounded-full text-secondary-500">
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center rounded-full">
         <Circle className="h-2.5 w-2.5 fill-current text-current" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>

--- a/src/hooks/datasets.ts
+++ b/src/hooks/datasets.ts
@@ -9,6 +9,7 @@ import API from 'services/api';
 type UseParams = {
   type?: 'monitors' | 'geostories' | 'all';
   monitor_id?: string;
+  sort_by?: 'title' | 'date';
 };
 
 const COLORS = (<{ [key: string]: string }>{

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -107,41 +107,8 @@
   }
 }
 
-/* CAROUSEL */
-.flicking-viewport {
-  @apply relative overflow-hidden;
-}
-
-.flicking-viewport:not(.vertical) {
-  @apply w-full h-full;
-}
-
-.flicking-camera {
-  @apply relative z-10 w-full h-full whitespace-nowrap will-change-transform;
-}
-
-.flicking-camera>* {
-  @apply inline-block whitespace-normal align-top;
-}
-
-.flicking-viewport.vertical,.flicking-viewport.vertical>.flicking-camera {
-  @apply inline-block;
-}
-
-.flicking-viewport.vertical.middle>.flicking-camera>* {
-  @apply align-middle;
-}
-
-.flicking-viewport.vertical.bottom>.flicking-camera>* {
-  @apply align-bottom;
-}
-
-.flicking-viewport.vertical>.flicking-camera>* {
-  @apply block;
-}
-
-.flicking-viewport.flicking-hidden>.flicking-camera>* {
-  @apply invisible;
+.dropdown-menu-content {
+  width: var(--radix-dropdown-menu-trigger-width) 
 }
 
 .visually-hidden {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,12 +2120,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash-es@npm:4.17.9":
-  version: 4.17.9
-  resolution: "@types/lodash-es@npm:4.17.9"
+"@types/lodash-es@npm:4.17.10":
+  version: 4.17.10
+  resolution: "@types/lodash-es@npm:4.17.10"
   dependencies:
     "@types/lodash": "*"
-  checksum: a2c7ab8da13892f89ab86b61dd9a0125c767b9db7b9bdaac7fd8508c9fa884bbb19a9760dbdc1e7e698e3322b7a8ba03daa80832371da32a8bd42da0920be838
+  checksum: 129e9dde830815a72f9bd17c3a7b7ffb10a9cf76d65c7bb4f14df13b38411ed3ebe9ebbc2f9059c4e61198e784d499e48d0a281e27a4defbbba748dd8a4cfd9d
   languageName: node
   linkType: hard
 
@@ -6147,6 +6147,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mitt@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mitt@npm:3.0.1"
+  checksum: b55a489ac9c2949ab166b7f060601d3b6d893a852515ae9eca4e11df01c013876df777ea109317622b5c1c60e8aae252558e33c8c94e14124db38f64a39614b1
+  languageName: node
+  linkType: hard
+
 "mkdirp@npm:^1.0.3":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
@@ -6231,6 +6238,17 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: deac9f8d00eda7b2e5cd1b2549e26e10a0faa70adaa6fdadca701cc55f49ee9018e427f424bac0c790b7c7e2d3068db97f3093f1093975f2acb8f8818b936ed9
+  languageName: node
+  linkType: hard
+
+"next-usequerystate@npm:1.9.2":
+  version: 1.9.2
+  resolution: "next-usequerystate@npm:1.9.2"
+  dependencies:
+    mitt: ^3.0.1
+  peerDependencies:
+    next: ^13.4 || ^14
+  checksum: ffc858c49d9c814526c446330e0f2db085175fcf4ead032ce2401757a96ea2e206bda2b7252711af83548c4d6c7400b3a966a2ffc856cd8abb42d5eb5789f893
   languageName: node
   linkType: hard
 
@@ -6564,7 +6582,7 @@ __metadata:
     "@tailwindcss/typography": 0.5.9
     "@tanstack/react-query": ^4.33.0
     "@types/google.analytics": 0.0.42
-    "@types/lodash-es": 4.17.9
+    "@types/lodash-es": 4.17.10
     "@types/node": 20.5.7
     "@types/ol-ext": "npm:@siedlerchr/types-ol-ext@3.2.4"
     "@types/react": 18.2.31
@@ -6591,6 +6609,7 @@ __metadata:
     lodash-es: ^4.17.21
     lucide-react: ^0.257.0
     next: 13.5.4
+    next-usequerystate: 1.9.2
     ol: 8.1.0
     ol-ext: ^4.0.11
     postcss: 8.4.21


### PR DESCRIPTION
## Sorting monitors and geostories in  the landing page

### Overview

_API is ready just to sort items by title._
The results come ordered by title and by monitors followed by geostories

### Designs

_[Link to the related design prototypes (if applicable)](https://www.figma.com/file/G3qygCzHDtdVaHdzudoH0G/%E2%9C%85-Open-Earth-Monitor---Prototype-%5BShared%5D---September?node-id=847%3A4308&mode=dev)_

### Testing instructions

_Landing page, click in dropdown (currently there is no possibility to change sorting criteria)._

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/OEMC-24?atlOrigin=eyJpIjoiZDYzZDRhMmY1NWE3NGQ1N2JjNzhjNjlmZDY4MzY2YjIiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

