### PR TITLE
back to monitor functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Unreleased
 - 404 - error management [OEMC-81](https://vizzuality.atlassian.net/browse/OEMC-81?atlOrigin=eyJpIjoiNWZkNTYwMjVkZGVjNDAwZGE2YWI3ZDgwMzgzOTRjMjEiLCJwIjoiaiJ9)
 - Sorting items in landing page [OEMC-24](https://vizzuality.atlassian.net/browse/OEMC-24?atlOrigin=eyJpIjoiZTlmNGE1Njk3MTRlNDNjMmExY2I3YmE1ZjUzMTBkYjIiLCJwIjoiaiJ9)
 - Alpha version tag added to site [OEMC-127](https://vizzuality.atlassian.net/browse/OEMC-127?atlOrigin=eyJpIjoiYzBiNGI0NDcwOGUzNGYzMzgzM2I1NWVhMWE0NjFkZjciLCJwIjoiaiJ9)
+- Functionality for returning from a geostory to its associated monitor [OEMC-121](https://vizzuality.atlassian.net/browse/OEMC-121?atlOrigin=eyJpIjoiNWY1OTkwZDNlMWNiNDA4M2JiOWM0NDNiODlkMDBlNmUiLCJwIjoiaiJ9)
 
 ### Changed
 

--- a/src/app/map/geostories/[geostory_id]/page.tsx
+++ b/src/app/map/geostories/[geostory_id]/page.tsx
@@ -1,8 +1,16 @@
 'use client';
 
+import { useMemo } from 'react';
+
+import Link from 'next/link';
+
 import type { NextPage } from 'next';
+import { HiArrowLeft } from 'react-icons/hi';
+
+import type { MonitorParsed } from '@/types/monitors';
 
 import { useGeostoryLayers } from '@/hooks/geostories';
+import { useMonitors } from '@/hooks/monitors';
 
 import DatasetCard from '@/components/datasets/card';
 import GeostoryHead from '@/components/geostories/header';
@@ -12,11 +20,30 @@ const GeostoryPage: NextPage<{ params: { geostory_id: string } }> = ({
   params: { geostory_id },
 }) => {
   const { data, isLoading, isFetched, isError } = useGeostoryLayers({ geostory_id });
+  const { data: monitors } = useMonitors();
+  const monitor = useMemo<MonitorParsed>(
+    () => monitors?.find(({ geostories }) => geostories.map(({ id }) => id === geostory_id)),
+    [monitors, geostory_id]
+  );
+
+  const { title: monitorTitle, id: monitorId, color } = monitor || {};
 
   return (
     <div className="space-y-6">
-      <GeostoryHead geostoryId={geostory_id} />
-
+      <div className="divide-y divide-secondary-900">
+        {monitorTitle && (
+          <Link
+            href={`/map/${monitorId}/geostories`}
+            className="block space-x-3 pb-8 font-bold"
+            data-testid="back-to-monitor"
+            style={{ color }}
+          >
+            <HiArrowLeft className="inline-block h-6 w-6" />
+            <span data-testid="monitor-title-back-btn">Back to {monitorTitle}.</span>
+          </Link>
+        )}
+        <GeostoryHead geostoryId={geostory_id} color={color} />
+      </div>
       <div>
         {isLoading && <Loading />}
 

--- a/src/components/geostories/header/index.tsx
+++ b/src/components/geostories/header/index.tsx
@@ -6,14 +6,16 @@ import { useGeostory } from '@/hooks/geostories';
 
 import Loading from '@/components/loading';
 
-const GeostoryHead: FC<{ geostoryId: Geostory['id'] }> = ({ geostoryId }) => {
+const GeostoryHead: FC<{ geostoryId: Geostory['id']; color: string }> = ({ geostoryId, color }) => {
   const { data, isLoading, isFetched, isError } = useGeostory({ geostory_id: geostoryId });
 
   return (
     <div className="space-y-6 px-6 py-5">
       {isLoading && !isFetched && <Loading />}
       {/* TODO - get color from API when we get categories */}
-      <div className="text-xs">GEOSTORY</div>
+      <div className="text-xs" style={{ color }}>
+        GEOSTORY
+      </div>
       {isFetched && !isError && (
         <>
           <h1 className="font-satoshi text-4xl font-bold">{data.title}</h1>

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,7 +1,7 @@
 import { cn } from 'lib/classnames';
 
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('animate-pulse rounded-md bg-primary/10', className)} {...props} />;
+  return <div className={cn('animate-pulse rounded-md bg-secondary-900', className)} {...props} />;
 }
 
 export { Skeleton };


### PR DESCRIPTION
## Back to monitor functionality from a geostory

### Overview

_As an OEMC user navigating a geostory, I need a way to go back to the monitor it belongs to without having to to use the header menu._

### Designs

_[Link to the related design prototypes (if applicable)](https://www.figma.com/file/Xz2WD4UWH3R6OdmeqmAMbF/%E2%9C%85-Open-Earth-Monitor---Prototype-%5BInternal%5D---September?node-id=123%3A3068&mode=dev)_

### Testing instructions

_Navigate from a geostory and click on one of the layers._

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/OEMC-114?atlOrigin=eyJpIjoiZDg2YmE5NDc4ZjBhNDAyYWI0MmUxYzY1ZWI5NGJkNWUiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

